### PR TITLE
fix wan,lan random mac address

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
@@ -90,8 +90,7 @@
 };
 
 &gmac0 {
-	nvmem-cells = <&macaddr_uboot_1fc20>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&uboot 0x1fc20>;
 };
 
 &switch0 {
@@ -99,8 +98,7 @@
 		port@0 {
 			status = "okay";
 			label = "wan";
-			nvmem-cells = <&macaddr_uboot_1fc40>;
-			nvmem-cell-names = "mac-address";
+			mtd-mac-address = <&uboot 0x1fc40>;
 		};
 
 		port@1 {
@@ -161,19 +159,5 @@
 	gpio {
 		groups = "wdt", "i2c", "uart3";
 		function = "gpio";
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
-
-	macaddr_uboot_1fc40: macaddr@1fc40 {
-		reg = <0x1fc40 0x6>;
 	};
 };


### PR DESCRIPTION
안녕하세요

작성해주신 dts에 대해 여쭤보고 싶은게 있어서 이렇게 남깁니다.
마땅한 곳이 없어서 pr로 남기는 점 양해 부탁드립니다 (__)

수정하신 내역 적용해서 빌드를 뽑아서 기기에 올려보니,
wan, lan mac이 random generate되고 있더라구요
(mtd-mac-address를 사용하면 정상 동작)

혹시 a8004t dts 처럼 mtd-mac-address를 사용하지 않고,
nvmem-cells를 사용하는 이유를 알 수 있을까요?